### PR TITLE
Fix maintenance mode activation in admin bar

### DIFF
--- a/inc/Maintenance.php
+++ b/inc/Maintenance.php
@@ -187,21 +187,21 @@ class Maintenance {
 	private function toggle_maintenance_mode( $wp_admin_bar ): void {
 		$enable_settings = get_option( 'enable_settings' );
 
-		if ( $enable_settings ) {
+		if ( ! $enable_settings ) {
 			$wp_admin_bar->add_node(
 				[
-					'id'     => 'deactivate_maintenance_mode',
-					'title'  => 'Deactivate',
-					'href'   => admin_url( 'admin-post.php?action=deactivate_maintenance_mode' ),
+					'id'     => 'activate_maintenance_mode',
+					'title'  => 'Activate',
+					'href'   => admin_url( 'admin-post.php?action=activate_maintenance_mode' ),
 					'parent' => 'maintenance_mode',
 				]
 			);
 		} else {
 			$wp_admin_bar->add_node(
 				[
-					'id'     => 'activate_maintenance_mode',
-					'title'  => 'Activate',
-					'href'   => admin_url( 'admin-post.php?action=activate_maintenance_mode' ),
+					'id'     => 'deactivate_maintenance_mode',
+					'title'  => 'Deactivate',
+					'href'   => admin_url( 'admin-post.php?action=deactivate_maintenance_mode' ),
 					'parent' => 'maintenance_mode',
 				]
 			);

--- a/utils-maintenance.php
+++ b/utils-maintenance.php
@@ -9,7 +9,7 @@
  * Plugin Name:   Maintenance
  * Plugin URI:    https://github.com/Stutz-Medien/Maintenance
  * Description:   Lightweight maintenance screen for your WordPress page.
- * Version:       1.3.2
+ * Version:       1.3.3
  * Author:        Stutz Medien
  * Author URI:    https://stutz-medien.ch/
  * Text Domain:   acf
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'UTILS_MAINTENANCE_VERSION', '1.3.2' );
+define( 'UTILS_MAINTENANCE_VERSION', '1.3.3' );
 
 if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	require_once __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
This pull request fixes an issue where the maintenance mode activation button in the admin bar was incorrectly labeled as "Deactivate" instead of "Activate". The commit "fix(admin bar): should now start with activate maintenance mode" addresses this issue.

Bump version number to 1.3.3